### PR TITLE
route messages by target system ID and component ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -323,11 +323,11 @@ func (p *program) run() {
 									targetComponent < 1 { // Route if compid matches or is a broadcast
 									if remoteNode.Channel != evt.Channel { // Prevents Loops
 										if cli.PrintRoutes {
-											fmt.Println("Routing msg ", evt.Message().GetID(), " from ", evt.Channel, "--->", remoteNode.Channel)
+											log.Println("Routing msg ", evt.Message().GetID(), " from ", evt.Channel, "--->", remoteNode.Channel)
 										}
 										p.node.WriteFrameTo(remoteNode.Channel, evt.Frame)
 									} else {
-										fmt.Println("Warning: channel ", remoteNode.Channel, " attempted to send to itself, discarding ")
+										log.Println("Warning: channel ", remoteNode.Channel, " attempted to send to itself, discarding ")
 									}
 								}
 							}

--- a/main.go
+++ b/main.go
@@ -92,7 +92,6 @@ var cli struct {
 	Version            bool `help:"print version."`
 	Quiet              bool `short:"q" help:"suppress info messages."`
 	Print              bool `help:"print routed frames."`
-	PrintRoutes        bool `help:"print routes applied for messages with targets."`
 	PrintErrors        bool
 	HbDisable          bool   `help:"disable heartbeats."`
 	HbVersion          string `enum:"1,2" help:"set mavlink version of heartbeats." default:"1"`
@@ -339,9 +338,6 @@ func (p *program) run() {
 								if remoteNode.ComponentID == targetComponent ||
 									targetComponent < 1 { // Route if compid matches or is a broadcast
 									if remoteNode.Channel != evt.Channel { // Prevents Loops
-										if cli.PrintRoutes {
-											log.Println("Routing msg ", evt.Message().GetID(), " from ", evt.Channel, "--->", remoteNode.Channel)
-										}
 										p.node.WriteFrameTo(remoteNode.Channel, evt.Frame)
 									} else {
 										log.Println("Warning: channel ", remoteNode.Channel, " attempted to send to itself, discarding ")

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProgram(t *testing.T) {
+func TestGeneric(t *testing.T) {
 	p, err := newProgram([]string{"--print", "tcps:0.0.0.0:6666"})
 	require.NoError(t, err)
 	defer p.close()
@@ -67,4 +67,100 @@ func TestProgram(t *testing.T) {
 	eventFr, ok = evt.(*gomavlib.EventFrame)
 	require.Equal(t, true, ok)
 	require.Equal(t, msg, eventFr.Frame.GetMessage())
+}
+
+func TestDirect(t *testing.T) {
+	p, err := newProgram([]string{"tcps:0.0.0.0:6666"})
+	require.NoError(t, err)
+	defer p.close()
+
+	pub, err := gomavlib.NewNode(gomavlib.NodeConf{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointTCPClient{
+				Address: "127.0.0.1:6666",
+			},
+		},
+		OutVersion:     gomavlib.V2,
+		OutSystemID:    4,
+		OutComponentID: 5,
+		Dialect:        common.Dialect,
+	})
+	require.NoError(t, err)
+	defer pub.Close()
+
+	sub1, err := gomavlib.NewNode(gomavlib.NodeConf{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointTCPClient{
+				Address: "127.0.0.1:6666",
+			},
+		},
+		OutVersion:     gomavlib.V2,
+		OutSystemID:    6,
+		OutComponentID: 7,
+		Dialect:        common.Dialect,
+	})
+	require.NoError(t, err)
+	defer sub1.Close()
+
+	sub2, err := gomavlib.NewNode(gomavlib.NodeConf{
+		Endpoints: []gomavlib.EndpointConf{
+			gomavlib.EndpointTCPClient{
+				Address: "127.0.0.1:6666",
+			},
+		},
+		OutVersion:     gomavlib.V2,
+		OutSystemID:    8,
+		OutComponentID: 9,
+		Dialect:        common.Dialect,
+	})
+	require.NoError(t, err)
+	defer sub2.Close()
+
+	<-pub.Events()
+	<-sub1.Events()
+	<-sub2.Events()
+
+	sub1.WriteMessageAll(&common.MessageHeartbeat{
+		Type:           common.MAV_TYPE_GCS,
+		SystemStatus:   4,
+		MavlinkVersion: 3,
+	})
+
+	sub2.WriteMessageAll(&common.MessageHeartbeat{
+		Type:           common.MAV_TYPE_GCS,
+		SystemStatus:   4,
+		MavlinkVersion: 3,
+	})
+
+	for i := 0; i < 2; i++ {
+		evt := <-pub.Events()
+		eventFr, ok := evt.(*gomavlib.EventFrame)
+		require.Equal(t, true, ok)
+		require.Equal(t, &common.MessageHeartbeat{
+			Type:           6,
+			SystemStatus:   4,
+			MavlinkVersion: 3,
+		}, eventFr.Frame.GetMessage())
+	}
+
+	msg := &common.MessageCommandLong{
+		TargetSystem:    6,
+		TargetComponent: 7,
+		Command:         common.MAV_CMD_NAV_FOLLOW,
+	}
+
+	pub.WriteMessageAll(msg)
+
+	<-sub1.Events()
+	evt := <-sub1.Events()
+	eventFr, ok := evt.(*gomavlib.EventFrame)
+	require.Equal(t, true, ok)
+	require.Equal(t, msg, eventFr.Frame.GetMessage())
+
+	<-sub2.Events()
+	select {
+	case <-sub2.Events():
+		t.Errorf("should not happen")
+	case <-time.After(100 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
This PR resolves #18 

This PR adds some basic routing functionality to the mavp2p tool. I tried my best to follow the standard as defined in - https://mavlink.io/en/guide/routing.html

I apologies for my Go skills, its my first time using Go!

The following rules are iterated over every connected node, every time a message is received:

1. If the message is of type COMMAND_LONG, COMMAND_ACK or COMMAND_INT then, read the `target_system` and `target_component` from it and mark the `routeMsg` variable true. Otherwise broadcast it. 
2. if target_system is more than 0 (non-broadcasted) then route it, otherwise broadcast it
`        if routeMsg { if targetSystem > 0 { // Route only if it's non-broadcast command`
3. if target_system matches the system id of one of the connected nodes then proceed with routing, otherwise discard
`           for remoteNode := range nh.remoteNodes { // Iterates through connected nodes `
`             if remoteNode.SystemID == targetSystem {`

4. If target_component matches a node or set to broadcast then route, otherwise discard
`                if remoteNode.ComponentID == targetComponent || targetComponent < 1 { // Route if compid matches or is a broadcast`
5. Does a check that the message is not addressed to itself, if it is then it discards and prints a warning
`                    if remoteNode.Channel != evt.Channel { // Prevents Loops`
6. Finally, if all of these criteria are met then the message is sent to the node
`                        node.WriteFrameTo(remoteNode.Channel, evt.Frame)`

When the cli arg `--print-routes` is used we can see the behaviour of the routed frames. Eg, here is the interaction of a GCS connecting to a camera video stream using this camera protocol - https://mavlink.io/en/services/camera.html#video_streaming. The COMMAND_LONGS are replied with COMMAND_ACKS etc. (I censored our public IP here)
![image](https://user-images.githubusercontent.com/70570048/236482262-d3497a83-3cfe-452e-9815-cb86cf7aba94.png)

Known Issues that should be fixed before merging:
- we only check a set of 3 messages if they have a `target_system` field. I’m not sure right now how to check for every incoming message.
- This routing goes against what @aler9 mentioned about:
> some nodes are meant to listen on all incoming traffic for saving telemetry, storing logs, broadcasting telemetry, debugging reasons. So there should be a way to keep the actual behavior on these nodes.

So we'd need to allow for some nodes to be marked as loggers or listeners or whatever...

