### PR TITLE
Ensure checksum recalculation for routed packets

### DIFF
--- a/message_handler.go
+++ b/message_handler.go
@@ -141,6 +141,9 @@ func (mh *messageHandler) onEventFrame(evt *gomavlib.EventFrame) {
 		}
 	}
 
+	// recalculate the checksum in case the incoming frame was truncated
+	mh.node.FixFrame(evt.Frame)
+
 	// if message has a target, route only to it
 	systemID, componentID, hasTarget := getTarget(evt.Message())
 	if hasTarget && systemID > 0 {


### PR DESCRIPTION
I noticed that for some packets the contents get truncated, but the checksum is never recalculated, resulting in a broken packet which the FC rightfully discards.

One particular case is with `COMMAND_LONG` and `COMMAND_INT`. As per MavLink spec they should have a 33 byte payload, but for reasons I'm still figuring out both gomavlib, MissionPlanner and mavproxy emit packets that have a 32 byte payload apparently discarding the `confirmation` field.

One particular software which emits 33 byte payload messages is [mavlink2rest](https://github.com/mavlink/mavlink2rest). When used in conjunction with mavp2p the following happens:
1. A 33 byte payload is received
2. Internally it's re-encoded and the payload is now 32 bytes
3. The checksum is kept from the incoming packet which is now invalid

When the same packet is sent via MP or mavproxy the payload is kept at 32 bytes as in the original packet therefore nothing is edited and thus the checksum does not need changes.

I was under impression that this had something to do with MavLink changes but the field was added years ago so I still don't know why there is a difference in sizes. But the protocol itself lends to alterations anyway so the propropsed change enforces the changed packets to have a checksum and/or signature recalculated. Maybe it can be done more elegantly e.g. by checking if the payload length is altered at any point or something like this.