### PR TITLE
Add packet sniffer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Flags:
       --hb-systemid=125                              System ID of heartbeats. It is recommended to set a different system id for each router in the network.
       --hb-componentid=191                           Component ID of heartbeats.
       --hb-period=5                                  Period of heartbeats.
+      --sniffer-sysid=0                              Forward all packets to this System ID(0 is disable sniffer mode)
       --streamreq-disable                            Do not request streams to Ardupilot devices, that need an explicit request in order to emit telemetry streams. This task
                                                      is usually delegated to the router, in order to avoid conflicts when multiple ground stations are active.
       --streamreq-frequency=4                        Stream frequency to request.

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ var cli struct {
 	HbSystemid         int           `default:"125"`
 	HbComponentid      int           `help:"Component ID of heartbeats." default:"191"`
 	HbPeriod           int           `help:"Period of heartbeats." default:"5"`
+	SnifferSysid       int           `help:"Forward all packets to this System ID(0 is disable sniffer mode)." default:"0"`
 	StreamreqDisable   bool
 	StreamreqFrequency int           `help:"Stream frequency to request." default:"4"`
 	Dump               bool          `help:"Dump telemetry to disk"`
@@ -283,6 +284,7 @@ func newProgram(args []string) (*program, error) {
 		Wg:               &p.wg,
 		StreamReqDisable: cli.StreamreqDisable,
 		Node:             p.node,
+		SnifferSysid:     cli.SnifferSysid,
 	}
 	err = p.messageMan.Initialize()
 	if err != nil {


### PR DESCRIPTION
Hello,

Please note that I am not fluent in English, so I used a translation tool to write this pull request. I apologize in advance for any awkward wording.

This contribution introduces a **sniffer feature**, inspired by the functionality provided in `mavlink-router`. The purpose is to enable a similar capability directly in `mavp2p`, allowing users to conveniently inspect MAVLink traffic without relying on external tools.

To use the sniffer feature, specify the desired system ID with the `--sniffer-sysid` startup option. This system ID will then be treated as a "sniffer." When enabled, `mavp2p` will attempt to forward all incoming packets to the designated sniffer. The default value is `0` (zero), which disables the feature. If forwarding is attempted back to the same sender (self-forwarding) or if the node with the specified sniffer system ID is not present on the network, a warning will be displayed and the forwarding will not be performed.

```bash
mavp2p --sniffer-sysid=30 udps:0.0.0.0:14550 # System ID 30 is treated as a 'sniffer'
```

I am not very familiar with the Go language, so some parts of my implementation may not fully follow common practices or might look unusual. I would greatly appreciate any feedback or suggestions for improvement.

Thank you for your consideration.